### PR TITLE
Fix 404 error on admin login page

### DIFF
--- a/app/Providers/Filament/AdmiiPanelProvider.php
+++ b/app/Providers/Filament/AdmiiPanelProvider.php
@@ -25,7 +25,7 @@ class AdmiiPanelProvider extends PanelProvider
         return $panel
             ->default()
             ->id('admii')
-            ->path('admii')
+            ->path('de/admii')
             ->login()
             ->colors([
                 'primary' => Color::Amber,


### PR DESCRIPTION
The admin login page was returning a 404 error because the URL was incorrect. The admin panel was configured to be at `/admii`, but the user was trying to access it at `/de/admii/login`.

This commit changes the admin panel path from `admii` to `de/admii` to match the URL structure of the rest of the site.