### PR TITLE
Disable authentication for the admin panel

### DIFF
--- a/app/Providers/Filament/AdmiiPanelProvider.php
+++ b/app/Providers/Filament/AdmiiPanelProvider.php
@@ -25,8 +25,7 @@ class AdmiiPanelProvider extends PanelProvider
         return $panel
             ->default()
             ->id('admii')
-            ->path('de/admii')
-            ->login()
+            ->path('admin')
             ->colors([
                 'primary' => Color::Amber,
             ])
@@ -44,15 +43,11 @@ class AdmiiPanelProvider extends PanelProvider
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,
                 StartSession::class,
-                AuthenticateSession::class,
                 ShareErrorsFromSession::class,
                 VerifyCsrfToken::class,
                 SubstituteBindings::class,
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
-            ])
-            ->authMiddleware([
-                Authenticate::class,
             ]);
     }
 }


### PR DESCRIPTION
As per an urgent user request, the authentication for the admin panel has been temporarily disabled. This is a major security risk and should be reverted as soon as possible.

The following changes were made to the AdmiiPanelProvider:
- The authentication middleware has been removed.
- The login page registration has been removed.
- The admin path has been set to '/admin'.

WARNING: This change makes the admin panel accessible to anyone without a login. It is critical to re-enable authentication as soon as the urgent task is completed.