### PR TITLE
Fix routing for German language sub-directory

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -5,29 +5,19 @@ use App\Http\Controllers\BiographyController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\HomepageController;
 
-/***
-|--------------------------------------------------------------------------
-| Web Routes for Production Server (ghanainsider.com/de)
-|--------------------------------------------------------------------------
-|
-| The web server's DocumentRoot is pointed to the /public directory.
-| The `/de` segment is part of the domain/subfolder setup and is not needed in the routes.
-|
-*/
+Route::group(['prefix' => 'de'], function() {
+    // --- Homepage Route ---
+    // This will handle the main domain: https://ghanainsider.com/de/
+    Route::get('/', [HomepageController::class, 'index'])->name('home');
 
-// --- Homepage Route ---
-// This will handle the main domain: https://ghanainsider.com/de/
-Route::get('/', [HomepageController::class, 'index'])->name('home');
+    // --- Guest Post Pages ---
+    // This will handle URLs like: https://ghanainsider.com/de/post/guest-post-slug
+    Route::get('/post/{slug}', [PostController::class, 'show'])
+        ->name('post.show');
 
-
-// --- Biography Pages ---
-// This will handle URLs like: https://ghanainsider.com/de/index.php/biography-slug
-Route::get('/index.php/{slug}', [BiographyController::class, 'show'])
-    ->where('slug', '[a-zA-Z0-9\-]+')
-    ->name('biography.show');
-
-
-// --- Guest Post Pages ---
-// This will handle URLs like: https://ghanainsider.com/de/index.php/post/guest-post-slug
-Route::get('/index.php/post/{slug}', [PostController::class, 'show'])
-    ->name('post.show');
+    // --- Biography Pages ---
+    // This will handle URLs like: https://ghanainsider.com/de/biography-slug
+    Route::get('/{slug}', [BiographyController::class, 'show'])
+        ->where('slug', '[a-zA-Z0-9\-]+')
+        ->name('biography.show');
+});


### PR DESCRIPTION
The application was not aware of the `/de` URL prefix, which caused 404 errors for posts, biographies, and after admin login.

This commit fixes the issue by:
- Wrapping all web routes in a `Route::group(['prefix' => 'de'])`.
- Cleaning up the routes by removing the unnecessary `/index.php` from the definitions.
- Reordering the routes to ensure that the more specific post route is matched before the general biography route.