### PR TITLE
Fix routing and biography controller error

### DIFF
--- a/app/Http/Controllers/BiographyController.php
+++ b/app/Http/Controllers/BiographyController.php
@@ -37,9 +37,7 @@ class BiographyController extends Controller
                 'title' => $relatedBio->full_name,
                 'excerpt' => Str::limit(strip_tags($relatedData['hero']['intro'] ?? ''), 100),
                 'image' => $relatedData['hero']['mainImageUrl'] ?? null,
-                // ########## THE FIX IS HERE ##########
-                // Use the correct master route name: 'page.show'
-                'url' => route('page.show', ['slug' => $relatedBio->slug]),
+                'url' => route('biography.show', ['slug' => $relatedBio->slug]),
             ];
         }
         


### PR DESCRIPTION
This commit fixes two issues:

1. The application was not aware of the `/de` URL prefix, which caused 404 errors for posts, biographies, and after admin login. This was fixed by wrapping all web routes in a `Route::group(['prefix' => 'de'])`.

2. The biography pages were throwing a `RouteNotFoundException` because the `BiographyController` was using an incorrect route name (`page.show` instead of `biography.show`) when generating URLs for related articles. This has been corrected.